### PR TITLE
feat: add WithHTTPClient option

### DIFF
--- a/messengers/slack/slack.go
+++ b/messengers/slack/slack.go
@@ -20,11 +20,12 @@ type HTTPClient interface {
 
 // Slack is a client to send messages to Slack.
 type Slack struct {
-	requester request.Requester
-	URL       string
-	Token     string
-	Message   Message
-	Timeout   time.Duration
+	requester  request.Requester
+	URL        string
+	Token      string
+	Message    Message
+	Timeout    time.Duration
+	HttpClient HTTPClient
 }
 
 // Message is the message to send to Slack.
@@ -101,6 +102,13 @@ func WithMessage(message Message) Option {
 	}
 }
 
+// WithHttpClient sets the Requester for the Slack client.
+func WithHttpClient(httpClient HTTPClient) Option {
+	return func(s *Slack) {
+		s.HttpClient = httpClient
+	}
+}
+
 // Send sends a message with blocks to a Slack channel.
 // Block messages are used to create rich messages with elements.
 // Doc: https://api.slack.com/reference/messaging/blocks
@@ -111,8 +119,6 @@ func (s *Slack) Send(ctx context.Context) error {
 		return fmt.Errorf("error marshaling message: %w", err)
 	}
 
-	httpClient := http.DefaultClient
-
 	resp, body, err := s.requester.Do(
 		ctx,
 		request.WithMethod(http.MethodPost),
@@ -120,7 +126,7 @@ func (s *Slack) Send(ctx context.Context) error {
 		request.WithHeader("Authorization", "Bearer "+s.Token),
 		request.WithHeader("Content-Type", "application/json"),
 		request.WithHeader("Accept", "application/json"),
-		request.WithClient(httpClient),
+		request.WithClient(s.HttpClient),
 		request.WithPayload(msg),
 	)
 	if err != nil {

--- a/messengers/slack/slack.go
+++ b/messengers/slack/slack.go
@@ -102,8 +102,8 @@ func WithMessage(message Message) Option {
 	}
 }
 
-// WithHttpClient sets the Requester for the Slack client.
-func WithHttpClient(httpClient HTTPClient) Option {
+// WithHTTPClient sets the Requester for the Slack client.
+func WithHTTPClient(httpClient HTTPClient) Option {
 	return func(s *Slack) {
 		s.HttpClient = httpClient
 	}

--- a/messengers/slack/slack_test.go
+++ b/messengers/slack/slack_test.go
@@ -14,23 +14,7 @@ import (
 func TestNewSlackMessenger(t *testing.T) {
 	t.Run("should create Slack messenger successfully", func(t *testing.T) {
 		messenger, err := NewSlackMessenger(
-			WithToken("test-token"),
-			WithTimeout(5*time.Second),
-			WithMessage(
-				Message{
-					Channel: "test-channel",
-					Content: []map[string]any{
-						{
-							"type": "section",
-							"text": map[string]string{
-								"type": "mrkdwn",
-								"text": "Hello, World!",
-							},
-						},
-					},
-				},
-			),
-			WithHttpClient(http.DefaultClient),
+			WithHTTPClient(http.DefaultClient),
 		)
 
 		assert.IsNil(t, err)

--- a/messengers/slack/slack_test.go
+++ b/messengers/slack/slack_test.go
@@ -28,7 +28,9 @@ func TestNewSlackMessenger(t *testing.T) {
 							},
 						},
 					},
-				}),
+				},
+			),
+			WithHttpClient(http.DefaultClient),
 		)
 
 		assert.IsNil(t, err)


### PR DESCRIPTION
**Objective** 
- Add an option to use a custom HTTP client in the Slack integration.  

**Changes Made**
* Added a new option WithHTTPClient to configure a custom HTTP client.
* Updated the Slack integration code to use the configured HTTP client if provided.
* Included unit tests to ensure the correct functionality of the new option.

**Motivation** 
* Allow greater flexibility in configuring the HTTP client, enabling the use of different implementations or specific configurations.  

**Example**

```golang
 customClient := &http.Client{}
 
 messenger, err := NewSlackMessenger(
	WithHTTPClient(customClient),
 )
```